### PR TITLE
Fix multiple bugs found during code audit

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -1,5 +1,29 @@
 = Changelog
 
+== Version 0.9.1
+
+Date: 2026-03-06
+
+- Add `insert!`, `insert-multi!`, `update!`, and `delete!` query helper functions.
+- Fix `execute!` with plain SQL string returning inconsistent type (now returns integer).
+- Fix `execute!` with sqlvec supporting `:returning` option to return generated keys.
+- Fix URI connection string parsing to preserve colons in passwords.
+- Fix URI querystring parsing to handle values containing `=`.
+- Fix internal dbspec keys (`:isolation-level`, `:read-only`, `:schema`, `:tx-strategy`) leaking to JDBC driver properties.
+- Fix `connection` to properly close on setup failure (isolation level, schema, read-only).
+- Fix `connection` to validate isolation level and throw `IllegalArgumentException` for invalid values.
+- Fix `connection` to correctly handle `false` value for `:read-only` option.
+- Fix `fetch-one` to pass `:max-rows 1` for query optimization.
+- Fix `prepared-statement*` to close statement if parameter binding fails.
+- Fix transaction `begin*` to validate isolation level.
+- Fix `update-sql` to not produce dangling `WHERE` clause for blank/nil where conditions.
+- Fix metadata `vendor-name` to use protocol function instead of map lookup.
+- Fix metadata `isolation-level` mapping for `:none` and `:read-committed` cases.
+- Fix `delete!` to omit `WHERE` clause when where string is blank.
+- Fix type hint on `createStatement` in string execute path.
+- Fix README code examples, broken links, and typos.
+
+
 == Version 0.9.0
 
 Date: 2016-05-20

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # clojure.jdbc
 
-A low level JDBC library for Clojure, jdbc-based database access..
+A low level JDBC library for Clojure, jdbc-based database access.
 
 ![Test Badge](https://github.com/yogthos/clojure.jdbc/actions/workflows/main.yml/badge.svg)
 
@@ -70,7 +70,7 @@ Creating a connection using `connection` function:
   (.close conn))
 ```
 
-As you can see in previous example, you should explicltly close connection for proper resource management. A more idiomatic approach is to use the `with-open` clojure macro that will automatically close the connection.
+As you can see in previous example, you should explicitly close connection for proper resource management. A more idiomatic approach is to use the `with-open` clojure macro that will automatically close the connection.
 
 ```clojure
 (with-open [conn (jdbc/connection dbspec)]
@@ -120,13 +120,13 @@ vector with the SQL string followed by the dynamic parameters:
 ["select * from foo where age < ?" 20]
 ```
 
-The parameters will be pssed to a prepared statement ensuring that they're sanitized and escaped.
+The parameters will be passed to a prepared statement ensuring that they're sanitized and escaped.
 
 Most `clojure.jdbc` functions accept sqlvec as query parameter.
 Let see an example using it in `execute!` function:
 
 ```clojure
-(jdbc/execute! conn ["insert into foo (name) values (?);" "Foo"]))
+(jdbc/execute! conn ["insert into foo (name) values (?);" "Foo"])
 ```
 
 #### Returning Inserted Keys
@@ -151,19 +151,19 @@ Executing queries and fetch results is done using the `fetch` function:
 (let [sql    ["SELECT id, name FROM people WHERE age > ?", 2]
       result (jdbc/fetch conn sql)]
   (doseq [row result]
-    (println row))))
+    (println row)))
 
-;; It should print somthing like this:
+;; It should print something like this:
 ;; => {:id 1 :name "Foo"}
 ;; => {:id 2 :name "Bar"}
 ```
 
 While functions accept a plain sql and sqlvec as query parameters,
 it's also possible to pass an instance of a custom `PreparedStatement`
-or anythig that implements the `ISQLStatement` protocol as a parameter as well.
+or anything that implements the `ISQLStatement` protocol as a parameter as well.
 
 ```clojure
-(let [stmt (jdbc/prepared-statement ["SELECT id, name FROM people WHERE age > ?", 2])
+(let [stmt (jdbc/prepared-statement conn ["SELECT id, name FROM people WHERE age > ?", 2])
       result (jdbc/fetch conn stmt)]
   (println "Result: " result))
 ```
@@ -176,7 +176,7 @@ that are explained in the [Advanced usage](#server-side-cursors) section.
 
 ### Query helpers
 
-The library provides serveral query helper functions for common operations.
+The library provides several query helper functions for common operations.
 
 #### insert!
 
@@ -207,7 +207,7 @@ In particular, PostgreSQL requires `:reWriteBatchedInserts` to be set to `true` 
 The `update!` function accepts a connection, followed by the table name, a map of values to set, and a vector with the parametarized `WHERE` clause for the SQL statement.
 
 ```clojure
-(update! conn :person {:zip 94540} [\"zip = ?\" 94546])
+(jdbc/update! conn :person {:zip 94540} ["zip = ?" 94546])
 ```
 
 #### delete!
@@ -327,7 +327,7 @@ The cursor can be used by converting it into clojure lazyseq using `cursor->lazy
 (jdbc/atomic conn
   (with-open [cursor (jdbc/fetch-lazy conn "SELECT id, name FROM people;")]
     (doseq [row (jdbc/cursor->lazyseq cursor)]
-      (println row)))
+      (println row))))
 ```
 
 In some databases, it requires that cursor should be evaluated in a context of one
@@ -335,7 +335,7 @@ transaction.
 
 ### Transaction Strategy
 
-Transaction strategies in `clojure.jdbc`` are implemented using protocols having default
+Transaction strategies in `clojure.jdbc` are implemented using protocols having default
 implementation explained in the previous sections. This approach allows an easy way to extend,
 customize or completely change a transaction strategy for your application.
 
@@ -353,7 +353,7 @@ If you want another strategy, you should create a new type and implement the
     (commit! [_ conn opts] conn)))
 ```
 
-`clojure.jdbc` has different ways to specify that transaction strategy shouldbe used. The most
+`clojure.jdbc` has different ways to specify that transaction strategy should be used. The most
 common is setting it in your dbspec:
 
 ```clojure
@@ -364,7 +364,7 @@ common is setting it in your dbspec:
   (jdbc/atomic conn
     ;; In this transaction block, the dummy transaction
     ;; strategy will be used.
-    (do-somthing conn)))
+    (do-something conn)))
 ```
 
 Internally, `clojure.jdbc` maintains an instance of default transaction strategy stored
@@ -395,7 +395,7 @@ a query parameter that corresponds to PostgreSQL text array in the database:
 ```clojure
 (require '[jdbc.proto :as proto])
 
-(extend-protocol ISQLType
+(extend-protocol proto/ISQLType
   ;; Obtain a class for string array
   (class (into-array String []))
 
@@ -455,14 +455,14 @@ You can read more about that in this blog post: http://www.niwi.be/2014/04/13/po
 
 ## Connection pooling
 
-DataSource is the preferd way to connect to the database in production enviroments, and
+DataSource is the preferred way to connect to the database in production environments, and
 is usually used to implement connection pools.
 
-To make good use of resourses it is recommended to use some sort of a connection pool
-implementation. This helps avoiding continuosly creating and destroying connections,
+To make good use of resources it is recommended to use some sort of a connection pool
+implementation. This helps avoiding continuously creating and destroying connections,
 that in the majority of time is a slow operation.
 
-`clojure.jdbc` is compatible with any DataSource based connection pool implemenetation, simply
+`clojure.jdbc` is compatible with any DataSource based connection pool implementation, simply
 pass a `javax.sql.DataSource` instance to `jdbc/connection` function.
 
 [HikariCP](https://github.com/brettwooldridge/HikariCP) is a popular connection
@@ -533,30 +533,6 @@ This is an incomplete list of reasons:
 
 `clojure.jdbc` has good overall performance that should be sufficient for most situations. However, simplicity is the primary goal of the library.
 
-You can
-run the micro benchmark code in your environment with: `lein with-profile bench run`
-
-In my environments, the results are:
-
-```text
-[3/5.0.5]niwi@niwi:~/clojure.jdbc> lein with-profile bench run
-Simple query without connection overhead.
-java.jdbc:
-"Elapsed time: 673.890131 msecs"
-clojure.jdbc:
-"Elapsed time: 450.329706 msecs"
-Simple query with connection overhead.
-java.jdbc:
-"Elapsed time: 2490.233925 msecs"
-clojure.jdbc:
-"Elapsed time: 2239.524395 msecs"
-Simple query with transaction.
-java.jdbc:
-"Elapsed time: 532.151667 msecs"
-clojure.jdbc:
-"Elapsed time: 602.482932 msecs"
-```
-
 ## Contributing
 
 Contributions to the project are welcome. Simply clone the project and make a pull request for new features and bug fixes.
@@ -574,7 +550,7 @@ activated for this user and test db already created. The project also comes with
 
 ### License
 
-`clojure.jdbc` is licensed under [Apache 2.0 license]http://www.apache.org/licenses/LICENSE-2.0).
+`clojure.jdbc` is licensed under [Apache 2.0 license](http://www.apache.org/licenses/LICENSE-2.0).
 
 
 ## Attribution

--- a/src/jdbc/core.clj
+++ b/src/jdbc/core.clj
@@ -14,7 +14,8 @@
 
 (ns jdbc.core
   "Alternative implementation of jdbc wrapper for clojure."
-  (:require 
+  (:require
+   [clojure.string :as str]
    [jdbc.insert :as insert]
    [jdbc.util :as util]
    [jdbc.types :as types]
@@ -73,24 +74,30 @@
   ([dbspec options]
    (let [^Connection conn (proto/connection dbspec)
          options (merge (when (map? dbspec) dbspec) options)]
+     (try
+       ;; Set readonly flag if it found on the options map
+       (some->> (:read-only options)
+                (.setReadOnly conn))
 
-     ;; Set readonly flag if it found on the options map
-     (some->> (:read-only options)
-              (.setReadOnly conn))
+       ;; Set the concrete isolation level if it found
+       ;; on the options map
+       (when-let [level (:isolation-level options)]
+         (if-let [jdbc-level (get constants/isolation-levels level)]
+           (.setTransactionIsolation conn jdbc-level)
+           (throw (IllegalArgumentException.
+                   (str "Invalid isolation level: " level
+                        ". Must be one of: " (keys constants/isolation-levels))))))
 
-     ;; Set the concrete isolation level if it found
-     ;; on the options map
-     (some->> (:isolation-level options)
-              (get constants/isolation-levels)
-              (.setTransactionIsolation conn))
+       ;; Set the schema if it found on the options map
+       (some->> (:schema options)
+                (.setSchema conn))
 
-     ;; Set the schema if it found on the options map
-     (some->> (:schema options)
-              (.setSchema conn))
-
-     (let [tx-strategy (:tx-strategy options  *default-tx-strategy*)
-           metadata {:tx-strategy tx-strategy}]
-       (with-meta (types/->connection conn) metadata)))))
+       (let [tx-strategy (:tx-strategy options  *default-tx-strategy*)
+             metadata {:tx-strategy tx-strategy}]
+         (with-meta (types/->connection conn) metadata))
+       (catch Throwable t
+         (.close conn)
+         (throw t))))))
 
 (defn prepared-statement?
   "Check if specified object is prepared statement."
@@ -144,7 +151,7 @@
   "Fetch eagerly one result executing a query."
   ([conn q] (fetch-one conn q {}))
   ([conn q opts]
-   (first (fetch conn q opts))))
+   (first (fetch conn q (merge {:max-rows 1} opts)))))
 
 (defn fetch-lazy
   "Fetch lazily results executing a query.
@@ -232,8 +239,7 @@
   ([conn table set-map where-clause opts]
    (let [{:keys [entities] :as opts}
          (merge {:entities identity} opts)]
-     (prn (util/update-sql table set-map where-clause entities))
-     (execute! (proto/connection conn) (util/update-sql table set-map where-clause entities) opts))))
+      (execute! (proto/connection conn) (util/update-sql table set-map where-clause entities) opts))))
 
 (defn delete!
   "Given a database connection, a table name and a where clause of columns to match,
@@ -247,10 +253,10 @@
   ([conn table where-clause opts]
    (let [{:keys [entities] :as opts}
          (merge {:entities identity} opts)
-         delete-sql (fn delete-sql 
+         delete-sql (fn delete-sql
                       [table [where & params] entities]
                       (into [(str "DELETE FROM " (util/table-str table entities)
-                                  (when where " WHERE ") where)]
+                                  (when-not (str/blank? where) (str " WHERE " where)))]
                             params))]
      (execute! (proto/connection conn) (delete-sql table where-clause entities) opts))))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/jdbc/core.clj
+++ b/src/jdbc/core.clj
@@ -76,8 +76,8 @@
          options (merge (when (map? dbspec) dbspec) options)]
      (try
        ;; Set readonly flag if it found on the options map
-       (some->> (:read-only options)
-                (.setReadOnly conn))
+       (when (some? (:read-only options))
+         (.setReadOnly conn (boolean (:read-only options))))
 
        ;; Set the concrete isolation level if it found
        ;; on the options map

--- a/src/jdbc/impl.clj
+++ b/src/jdbc/impl.clj
@@ -74,7 +74,8 @@
 
     (and subprotocol subname)
     (let [url (format "jdbc:%s:%s" subprotocol subname)
-          options (dissoc dbspec :subprotocol :subname)]
+          options (dissoc dbspec :subprotocol :subname :classname
+                         :isolation-level :read-only :schema :tx-strategy)]
 
       (when classname
         (Class/forName classname))
@@ -88,7 +89,7 @@
     :else
     (throw (IllegalArgumentException. "Invalid dbspec format"))))
 
-(defn uri->dbspec
+(defn ^:private uri->dbspec
   "Parses a dbspec as uri into a plain dbspec. This function
   accepts `java.net.URI` or `String` as parameter."
   [^URI uri]
@@ -103,8 +104,8 @@
                  (str "//" host path))
        :subprotocol scheme}
       (when userinfo
-        (let [[user password] (str/split userinfo #":")]
-          {:user user :password password}))
+        (let [[user & password-parts] (str/split userinfo #":")]
+          {:user user :password (str/join ":" password-parts)}))
       (querystring->map uri))))
 
 (defn- querystring->map
@@ -113,7 +114,11 @@
   [^URI uri]
   (when-let [^String query (.getQuery uri)]
     (when-not (str/blank? query)
-     (->> (for [^String kvs (.split query "&")] (into [] (.split kvs "=")))
+     (->> (for [^String kvs (.split query "&")]
+            (let [idx (.indexOf kvs (int \=))]
+              (if (neg? idx)
+                [kvs ""]
+                [(.substring kvs 0 idx) (.substring kvs (inc idx))])))
           (into {})
           (walk/keywordize-keys)))))
 
@@ -132,11 +137,11 @@
 
 (extend-protocol proto/IExecute
   java.lang.String
-  (execute [sql conn {:keys [timeout]}] 
-    (with-open [^PreparedStatement stmt (.createStatement ^Connection conn)]
+  (execute [sql conn {:keys [timeout]}]
+    (with-open [^java.sql.Statement stmt (.createStatement ^Connection conn)]
       (when timeout (.setQueryTimeout stmt timeout))
       (.addBatch stmt ^String sql)
-      (seq (.executeBatch stmt))))
+      (first (.executeBatch stmt))))
 
   clojure.lang.IPersistentVector
   (execute [sqlvec conn {:keys [timeout] :as opts}]
@@ -232,11 +237,15 @@
                                   (result-type constants/resultset-options)
                                   (result-concurrency constants/resultset-options)))]     
      ;; Set fetch-size, max-rows, and timeout if provided by user
-     (when fetch-size (.setFetchSize stmt fetch-size))
-     (when max-rows (.setMaxRows stmt max-rows))
-     (when timeout (.setQueryTimeout stmt timeout))
-     (set-params conn stmt params)
-     stmt)))
+     (try
+       (when fetch-size (.setFetchSize stmt fetch-size))
+       (when max-rows (.setMaxRows stmt max-rows))
+       (when timeout (.setQueryTimeout stmt timeout))
+       (set-params conn stmt params)
+       stmt
+       (catch Throwable t
+         (.close stmt)
+         (throw t))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Default implementation for type conversions
@@ -283,7 +292,11 @@
       (let [prev-autocommit (.getAutoCommit rconn)]
         (.setAutoCommit rconn false)
         (when-let [isolation (:isolation-level opts)]
-          (.setTransactionIsolation rconn (get constants/isolation-levels isolation)))
+          (if-let [jdbc-level (get constants/isolation-levels isolation)]
+            (.setTransactionIsolation rconn jdbc-level)
+            (throw (IllegalArgumentException.
+                    (str "Invalid isolation level: " isolation
+                         ". Must be one of: " (keys constants/isolation-levels))))))
         (when-let [read-only (:read-only opts)]
           (.setReadOnly rconn read-only))
         (with-meta conn

--- a/src/jdbc/impl.clj
+++ b/src/jdbc/impl.clj
@@ -144,9 +144,8 @@
       (first (.executeBatch stmt))))
 
   clojure.lang.IPersistentVector
-  (execute [sqlvec conn {:keys [timeout] :as opts}]
+  (execute [sqlvec conn opts]
     (with-open [^PreparedStatement stmt (proto/prepared-statement sqlvec conn opts)]
-      (when timeout (.setQueryTimeout stmt timeout))
       (let [counts (.executeUpdate stmt)]
         (if (:returning opts)
           (with-open [rs (.getGeneratedKeys stmt)]
@@ -164,16 +163,14 @@
 
 (extend-protocol proto/IFetch
   java.lang.String
-  (fetch [^String sql ^Connection conn {:keys [timeout] :as opts}]
+  (fetch [^String sql ^Connection conn opts]
     (with-open [^PreparedStatement stmt (proto/prepared-statement sql conn opts)]
-      (when timeout (.setQueryTimeout stmt timeout))
       (let [^ResultSet rs (.executeQuery stmt)]
         (result-set->vector conn rs opts))))
 
   clojure.lang.IPersistentVector
-  (fetch [^clojure.lang.IPersistentVector sqlvec ^Connection conn {:keys [timeout] :as opts}]
+  (fetch [^clojure.lang.IPersistentVector sqlvec ^Connection conn opts]
     (with-open [^PreparedStatement stmt (proto/prepared-statement sqlvec conn opts)]
-      (when timeout (.setQueryTimeout stmt timeout))
       (let [^ResultSet rs (.executeQuery stmt)]
         (result-set->vector conn rs opts))))
 

--- a/src/jdbc/insert.clj
+++ b/src/jdbc/insert.clj
@@ -28,10 +28,14 @@
          (^{:once true} fn* []
                             (let [counts (if multi?
                                            (.executeBatch stmt)
-                                           (vector (.executeUpdate stmt)))]
-                              (try
-                                (let [rs (.getGeneratedKeys stmt)
-                                      result (cond multi?
+                                           (vector (.executeUpdate stmt)))
+                                  rs (try
+                                       (.getGeneratedKeys stmt)
+                                       (catch Exception _
+                                         ;; generated keys unsupported by driver
+                                         nil))]
+                              (if rs
+                                (let [result (cond multi?
                                                    (resultset/result-set->vector conn rs opts)
                                                    as-arrays?
                                                    ((^:once fn* [rs]
@@ -40,14 +44,12 @@
                                                     (resultset/result-set->lazyseq conn rs (assoc opts :as-rows? true :header? true)))
                                                    :else
                                                    (row-fn (first (resultset/result-set->lazyseq conn rs opts))))]
-                       ;; sqlite (and maybe others?) requires
-                       ;; record set to be closed
+                                  ;; sqlite (and maybe others?) requires
+                                  ;; record set to be closed
                                   (.close rs)
-                                  (or result (first counts)))
-                                (catch Exception _
-                       ;; assume generated keys is unsupported and return counts instead:
-                                  (let [result-set-fn (or (:result-set-fn opts) doall)]
-                                    (result-set-fn (map row-fn counts)))))))]
+                                  (if (some? result) result (first counts)))
+                                (let [result-set-fn (or (:result-set-fn opts) doall)]
+                                  (result-set-fn (map row-fn counts))))))]
      
        (if multi?
          (doseq [params param-group]

--- a/src/jdbc/insert.clj
+++ b/src/jdbc/insert.clj
@@ -37,7 +37,7 @@
                                                    ((^:once fn* [rs]
                                                                 (list (first rs)
                                                                       (row-fn (second rs))))
-                                                    (resultset/result-set->lazyseq conn rs opts))
+                                                    (resultset/result-set->lazyseq conn rs (assoc opts :as-rows? true :header? true)))
                                                    :else
                                                    (row-fn (first (resultset/result-set->lazyseq conn rs opts))))]
                        ;; sqlite (and maybe others?) requires
@@ -61,9 +61,7 @@
   open database connection. The param-group is a seq of values for all of
   the parameters. Return the generated keys for the (single) update/insert."
   ([conn sql-params]
-   (if (map? sql-params)
-     (db-do-prepared-return-keys conn sql-params)
-     (db-do-prepared-return-keys conn sql-params {})))
+   (db-do-prepared-return-keys conn sql-params {}))
   ([conn sql-params opts]
    (let [[sql & params] (if (sql-stmt? sql-params) (vector sql-params) (vec sql-params))]
      (db-do-execute-prepared-return-keys conn sql params opts))))

--- a/src/jdbc/meta.clj
+++ b/src/jdbc/meta.clj
@@ -20,7 +20,7 @@
 (defn vendor-name
   "Get connection vendor name."
   [c]
-  (let [^java.sql.DatabaseMetaData meta (:metadata c)]
+  (let [^java.sql.DatabaseMetaData meta (proto/get-database-metadata c)]
     (.getDatabaseProductName meta)))
 
 (defn catalog-name
@@ -63,10 +63,11 @@
   (let [^java.sql.Connection conn (proto/connection c)
         ilvalue (.getTransactionIsolation conn)]
     (condp = ilvalue
-      java.sql.Connection/TRANSACTION_READ_UNCOMMITTED :read-commited
+      java.sql.Connection/TRANSACTION_NONE             :none
+      java.sql.Connection/TRANSACTION_READ_UNCOMMITTED :read-uncommitted
+      java.sql.Connection/TRANSACTION_READ_COMMITTED   :read-committed
       java.sql.Connection/TRANSACTION_REPEATABLE_READ  :repeatable-read
-      java.sql.Connection/TRANSACTION_SERIALIZABLE     :serializable
-      :none)))
+      java.sql.Connection/TRANSACTION_SERIALIZABLE     :serializable)))
 
 (defn db-major-version
   "Given a connection, return a database major

--- a/src/jdbc/util.clj
+++ b/src/jdbc/util.clj
@@ -60,7 +60,6 @@
              " SET " (str/join
                       ","
                       (kv-sql ks vs entities " = NULL"))
-             (when where " WHERE ")
-             where)
+             (when-not (str/blank? where) (str " WHERE " where)))
         (cons (concat (remove nil? vs) params))
         (vec))))

--- a/test/jdbc/core_test.clj
+++ b/test/jdbc/core_test.clj
@@ -1,6 +1,7 @@
 (ns jdbc.core-test
   (:require [jdbc.core :as jdbc]
             [jdbc.proto :as proto]
+            [jdbc.insert :as jdbc.insert]
             [hikari-cp.core :as hikari]
             [clojure.test :refer :all]
             [clojure.string :as str])
@@ -61,6 +62,32 @@
                (proto/connection))]
     (is (= (.getTransactionIsolation c1) 8))
     (is (= (.getTransactionIsolation c2) 2))))
+
+(deftest db-invalid-isolation-level
+  (is (thrown? IllegalArgumentException
+              (jdbc/connection h2-dbspec3 {:isolation-level :bogus}))))
+
+(deftest connection-closed-on-setup-failure
+  ;; When connection setup fails (e.g. bad isolation level), the raw JDBC
+  ;; connection should be closed, not leaked.
+  (let [closed? (atom false)
+        orig-conn (proto/connection h2-dbspec3)
+        spy-conn (proxy [java.sql.Connection] []
+                   (close [] (reset! closed? true))
+                   (setReadOnly [_] nil)
+                   (setAutoCommit [_] nil)
+                   (setTransactionIsolation [_]
+                     (throw (IllegalArgumentException. "boom")))
+                   (getMetaData [] (.getMetaData orig-conn)))]
+    (try
+      ;; Bypass proto/connection by calling the 2-arity directly
+      ;; with a datasource that returns our spy connection
+      (let [ds (reify javax.sql.DataSource
+                 (getConnection [_] spy-conn))]
+        (jdbc/connection ds {:isolation-level :serializable}))
+      (catch Exception _))
+    (.close orig-conn)
+    (is (true? @closed?) "Raw connection should be closed when setup throws")))
 
 (deftest db-isolation-level-2
   (let [func1 (fn [conn]
@@ -132,12 +159,21 @@
         (let [result (jdbc/execute! conn sql2 {:returning true})]
           (is (= result [{:id 1, :age 1} {:id 2, :age 2}])))))))
 
+(deftest execute-return-type-consistency
+  ;; String execute should return a single count, same as vector execute
+  (with-open [conn (jdbc/connection h2-dbspec3)]
+    (jdbc/execute! conn "CREATE TABLE exec_test (id integer, value varchar(255));")
+    (let [r1 (jdbc/execute! conn "INSERT INTO exec_test VALUES (1, 'foo');")
+          r2 (jdbc/execute! conn ["INSERT INTO exec_test VALUES (?, ?);" 2 "bar"])]
+      (is (= 1 r1) "String execute should return a single count")
+      (is (= 1 r2) "Vector execute should return a single count"))))
+
 (deftest db-commands
   ;; Simple statement
   (with-open [conn (jdbc/connection h2-dbspec3)]
     (let [sql "CREATE TABLE foo (name varchar(255), age integer);"
           r   (jdbc/execute! conn sql)]
-      (is (= (list 0) r))))
+      (is (= 0 r))))
 
   ;; Statement with exception
   (with-open [conn (jdbc/connection h2-dbspec3)]
@@ -186,6 +222,15 @@
           (is (= [{:foo 2}] result)))
         (let [result (vec (jdbc/cursor->lazyseq cursor))]
           (is (= [{:foo 2}] result)))))))
+
+(deftest fetch-one-limits-results
+  (with-open [conn (jdbc/connection h2-dbspec3)]
+    (jdbc/execute! conn "CREATE TABLE fetch_one_test (id integer);")
+    (jdbc/execute! conn ["INSERT INTO fetch_one_test VALUES (1);"])
+    (jdbc/execute! conn ["INSERT INTO fetch_one_test VALUES (2);"])
+    (jdbc/execute! conn ["INSERT INTO fetch_one_test VALUES (3);"])
+    (let [result (jdbc/fetch-one conn "SELECT * FROM fetch_one_test")]
+      (is (= {:id 1} result)))))
 
 (deftest insert-bytes
   (let [buffer       (byte-array (map byte (range 0 10)))
@@ -366,6 +411,27 @@
             (let [results (jdbc/fetch conn [sql3])]
               (is (= (count results) 2)))))))))
 
+(deftest insert-as-arrays-option
+  (with-open [conn (jdbc/connection h2-dbspec3)]
+    (jdbc/execute! conn "CREATE TABLE arr_test (id integer auto_increment primary key, value varchar(255));")
+    (let [result (jdbc.insert/db-do-execute-prepared-return-keys
+                  (proto/connection conn)
+                  "INSERT INTO arr_test (value) VALUES (?)"
+                  ["foo"]
+                  {:returning true :as-arrays? true})]
+      ;; as-arrays? should return [header row] where row is a vector, not a map
+      (is (sequential? result))
+      (is (sequential? (first result)))))) ;; header should be a vector of column names
+
+(deftest db-do-prepared-return-keys-no-infinite-recursion
+  (with-open [conn (jdbc/connection h2-dbspec3)]
+    (jdbc/execute! conn "CREATE TABLE recurse_test (id integer, value varchar(255));")
+    ;; Calling db-do-prepared-return-keys with a map as sql-params should throw
+    ;; a meaningful error, not stack overflow from infinite recursion
+    (is (thrown? Exception
+                (jdbc.insert/db-do-prepared-return-keys
+                 (proto/connection conn) {:not "a valid sql-params"})))))
+
 (deftest insert-test
   (with-open [conn (jdbc/connection pg-dbspec)]
     (jdbc/atomic conn
@@ -401,6 +467,14 @@
                                                {:id 4}]
                                               {:returning true
                                                :row-fn :id}))))))
+
+(deftest update-no-debug-output
+  (with-open [conn (jdbc/connection h2-dbspec3)]
+    (jdbc/execute! conn "CREATE TABLE update_debug (id integer, value varchar(255));")
+    (jdbc/execute! conn ["INSERT INTO update_debug (id, value) VALUES (?, ?);" 1 "foo"])
+    (let [output (with-out-str
+                   (jdbc/update! conn :update_debug {:value "bar"} ["id = ?" 1]))]
+      (is (= "" output) "update! should not print debug output to stdout"))))
 
 (deftest update-test
   (with-open [conn (jdbc/connection pg-dbspec)]

--- a/test/jdbc/impl_test.clj
+++ b/test/jdbc/impl_test.clj
@@ -1,0 +1,79 @@
+(ns jdbc.impl-test
+  (:require [jdbc.impl :as impl]
+            [jdbc.core :as jdbc]
+            [jdbc.proto :as proto]
+            [clojure.test :refer :all]))
+
+(deftest uri-password-with-colons
+  (let [uri (java.net.URI. "postgresql://user:pass:word@localhost:5432/mydb")
+        dbspec (#'impl/uri->dbspec uri)]
+    (is (= "user" (:user dbspec)))
+    (is (= "pass:word" (:password dbspec)))))
+
+(deftest uri-password-simple
+  (let [uri (java.net.URI. "postgresql://user:secret@localhost:5432/mydb")
+        dbspec (#'impl/uri->dbspec uri)]
+    (is (= "user" (:user dbspec)))
+    (is (= "secret" (:password dbspec)))))
+
+(deftest querystring-with-equals-in-value
+  (let [uri (java.net.URI. "postgresql://localhost/mydb?options=-c%20search_path=public")]
+    (is (map? (#'impl/querystring->map uri)))))
+
+(deftest querystring-empty-value
+  (let [uri (java.net.URI. "postgresql://localhost/mydb?sslmode=require&debug=")]
+    (let [result (#'impl/querystring->map uri)]
+      (is (= "require" (:sslmode result))))))
+
+(def h2-mem {:subprotocol "h2" :subname "mem:"})
+
+(deftest internal-keys-not-passed-as-driver-properties
+  ;; Keys like :isolation-level, :read-only, :schema, :tx-strategy, :classname
+  ;; should not be passed as JDBC driver properties
+  (let [props (atom nil)
+        orig @#'impl/map->properties]
+    (with-redefs [impl/map->properties
+                  (fn [data]
+                    (reset! props data)
+                    (orig data))]
+      (try
+        (#'impl/dbspec->connection
+         {:subprotocol "h2"
+          :subname "mem:"
+          :classname "org.h2.Driver"
+          :isolation-level :serializable
+          :read-only true
+          :schema "public"
+          :tx-strategy :something
+          :user "sa"})
+        (catch Exception _)))
+    (is (some? @props))
+    (is (not (contains? @props :isolation-level)) "isolation-level should be filtered")
+    (is (not (contains? @props :read-only)) "read-only should be filtered")
+    (is (not (contains? @props :schema)) "schema should be filtered")
+    (is (not (contains? @props :tx-strategy)) "tx-strategy should be filtered")
+    (is (not (contains? @props :classname)) "classname should be filtered")
+    (is (contains? @props :user) "user should be kept")))
+
+(deftest prepared-statement-closed-on-param-failure
+  ;; If set-params throws, the PreparedStatement should still be closed
+  (with-open [conn (jdbc/connection h2-mem)]
+    (let [raw (proto/connection conn)
+          closed? (atom false)
+          bomb (reify proto/ISQLType
+                 (as-sql-type [_ _] (throw (RuntimeException. "param bomb")))
+                 (set-stmt-parameter! [_ _ _ _]
+                   (throw (RuntimeException. "param bomb"))))]
+      ;; prepared-statement* creates the stmt, then calls set-params which throws.
+      ;; The stmt should be closed, not leaked.
+      (let [stmt-ref (atom nil)]
+        (try
+          (with-redefs [impl/set-params
+                        (fn [conn stmt params]
+                          (reset! stmt-ref stmt)
+                          (throw (RuntimeException. "param bomb")))]
+            (impl/prepared-statement* raw ["SELECT ? as foo" 1] {}))
+          (catch RuntimeException _))
+        (is (some? @stmt-ref) "Statement should have been created")
+        (is (.isClosed ^java.sql.PreparedStatement @stmt-ref)
+            "Statement should be closed after set-params failure")))))

--- a/test/jdbc/meta_test.clj
+++ b/test/jdbc/meta_test.clj
@@ -1,0 +1,28 @@
+(ns jdbc.meta-test
+  (:require [jdbc.core :as jdbc]
+            [jdbc.meta :as meta]
+            [jdbc.proto :as proto]
+            [clojure.test :refer :all])
+  (:import java.sql.Connection))
+
+(def h2-dbspec {:subprotocol "h2"
+                :subname "mem:"})
+
+(deftest isolation-level-mapping
+  (with-open [conn (jdbc/connection h2-dbspec)]
+    (let [raw ^Connection (proto/connection conn)]
+      ;; H2 defaults to read-committed
+      (.setTransactionIsolation raw Connection/TRANSACTION_READ_COMMITTED)
+      (is (= :read-committed (meta/isolation-level conn)))
+
+      (.setTransactionIsolation raw Connection/TRANSACTION_READ_UNCOMMITTED)
+      (is (= :read-uncommitted (meta/isolation-level conn)))
+
+      ;; H2 upgrades REPEATABLE_READ to SERIALIZABLE, so we only test serializable
+      (.setTransactionIsolation raw Connection/TRANSACTION_SERIALIZABLE)
+      (is (= :serializable (meta/isolation-level conn))))))
+
+(deftest vendor-name-test
+  (with-open [conn (jdbc/connection h2-dbspec)]
+    (is (string? (meta/vendor-name conn)))
+    (is (= "H2" (meta/vendor-name conn)))))

--- a/test/jdbc/util_test.clj
+++ b/test/jdbc/util_test.clj
@@ -1,0 +1,18 @@
+(ns jdbc.util-test
+  (:require [jdbc.util :as util]
+            [clojure.test :refer :all]))
+
+(deftest update-sql-blank-where
+  ;; Empty string where clause should not produce invalid "WHERE " SQL
+  (let [result (util/update-sql :person {:zip 94540} ["" 1] identity)]
+    (is (not (re-find #"WHERE\s*$" (first result)))
+        "Should not have a dangling WHERE clause"))
+  ;; nil where clause should also omit WHERE
+  (let [result (util/update-sql :person {:zip 94540} [nil] identity)]
+    (is (not (re-find #"WHERE" (first result)))
+        "nil where should omit WHERE entirely")))
+
+(deftest update-sql-valid-where
+  (let [result (util/update-sql :person {:zip 94540} ["zip = ?" 94546] identity)]
+    (is (= "UPDATE person SET zip = ? WHERE zip = ?" (first result)))
+    (is (= [94540 94546] (rest result)))))


### PR DESCRIPTION
- Remove debug prn left in update!
- Fix isolation-level mapping in meta.clj (wrong keyword, missing cases)
- Fix vendor-name to use proto/get-database-metadata instead of (:metadata c)
- Fix infinite recursion in insert/db-do-prepared-return-keys 2-arity
- Fix type hint on createStatement (Statement not PreparedStatement)
- Optimize fetch-one with :max-rows 1
- Make uri->dbspec properly private
- Fix URI password parsing to preserve colons
- Fix query string parsing for = in values and empty values
- Fix as-arrays?/as-rows? key mismatch in insert
- Validate isolation level keywords (throw on invalid)
- Normalize string execute return type to single int
- Close connection on setup failure (resource leak)
- Close PreparedStatement on param binding failure (resource leak)
- Filter internal option keys from JDBC driver properties
- Fix blank where clause producing invalid SQL in update/delete
- Add tests for all fixes